### PR TITLE
Wikivisor

### DIFF
--- a/Form/Image.mediawiki
+++ b/Form/Image.mediawiki
@@ -72,7 +72,7 @@ if a page with that name already exists, you will be sent to a form to edit that
 | {{{field|Edition}}}
 |-
 ! Page:
-| {{{field|Page}}}
+| {{{field|Page number}}}
 |-
 ! Figure:
 | {{{field|Figure}}}

--- a/Property/Page number.mediawiki
+++ b/Property/Page number.mediawiki
@@ -1,0 +1,1 @@
+This is a property of type [[Has type::Text]].

--- a/Property/Page number.mediawiki
+++ b/Property/Page number.mediawiki
@@ -1,1 +1,0 @@
-This is a property of type [[Has type::Text]].

--- a/Property/Page.mediawiki
+++ b/Property/Page.mediawiki
@@ -1,1 +1,0 @@
-This is a property of type [[Has type::Text]].

--- a/Template/Image.mediawiki
+++ b/Template/Image.mediawiki
@@ -55,7 +55,7 @@
 }}
 ;Volume: [[Volume::{{{Volume|}}}]]
 ;Edition: [[Edition::{{{Edition|}}}]]
-;Page: [[Pages::{{{Page|}}}]]
+;Page: [[Pages::{{{Page number|}}}]]
 ;Figure: [[Figure::{{{Figure|}}}]]
 ;Repository: [[Repository::{{{Repository|}}}]]
 ;Zotero ID: [[Reference ID::{{{Reference ID|}}}]]

--- a/page-exchange.json
+++ b/page-exchange.json
@@ -100,7 +100,7 @@
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/heald-images\/master\/Property%2FPerson.mediawiki"
                 },
                 {
-                    "name": "Page",
+                    "name": "Page number",
                     "namespace": "SMW_NS_PROPERTY",
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/heald-images\/master\/Property%2FPage.mediawiki"
                 },

--- a/page-exchange.json
+++ b/page-exchange.json
@@ -100,11 +100,6 @@
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/heald-images\/master\/Property%2FPerson.mediawiki"
                 },
                 {
-                    "name": "Page number",
-                    "namespace": "SMW_NS_PROPERTY",
-                    "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/heald-images\/master\/Property%2FPage.mediawiki"
-                },
-                {
                     "name": "Figure",
                     "namespace": "SMW_NS_PROPERTY",
                     "url": "https:\/\/raw.githubusercontent.com\/WikiTeq\/heald-images\/master\/Property%2FFigure.mediawiki"


### PR DESCRIPTION
At a closer look, it was noted that the data is stored in 'Pages' property. 'Page' property is not used and can be safely removed